### PR TITLE
change halfcplt to cplt

### DIFF
--- a/main.c
+++ b/main.c
@@ -464,7 +464,7 @@ void HAL_TIM_PeriodElapsedCallback(TIM_HandleTypeDef *htim)
 	}
 }
 
-void HAL_ADC_ConvHalfCpltCallback(ADC_HandleTypeDef* hadc){
+void HAL_ADC_ConvCpltCallback(ADC_HandleTypeDef* hadc){
 	if(HAL_ADC_Stop_DMA(&hadc1) != HAL_OK) Error_Handler();
 	//if(ADCData[0] < 2000 && ADCData[1] < 2000) outpwm(0);
 	if(ADCData[1] == 0) outpwm(0);


### PR DESCRIPTION
I change the function name from HAL_ADC_ConvHalfCpltCallback to HAL_ADC_ConvCpltCallback. Because the half one finish at 1-byte translation. If you want to transfer 2-bytes, you need to use the cplt one.